### PR TITLE
Changes required by gliffy project

### DIFF
--- a/lib/rerouter.js
+++ b/lib/rerouter.js
@@ -62,6 +62,9 @@ rerouter._generateSanePath = newRequest => {
     path.shift()
     path = path.join(jsonApi._apiConfig.base)
   }
+  if (jsonApi._apiConfig.urlPrefixAlias) {
+    path = path.replace(jsonApi._apiConfig.urlPrefixAlias, '')
+  }
   path = path.replace(/^\//, '').split('?')[0].replace(/\/$/, '')
   return path
 }

--- a/lib/router.js
+++ b/lib/router.js
@@ -108,7 +108,7 @@ router.bindRoute = (config, callback) => {
 
   const routeHandler = (req, res, extras) => {
     let request = router._getParams(req)
-    request = _.assign(request, extras)
+    request = _.assign(request, { originalReq: req, originalRes: res }, extras)
     const resourceConfig = jsonApi._resources[request.params.type]
     request.resourceConfig = resourceConfig
     res._request = request

--- a/lib/routes/_swagger.js
+++ b/lib/routes/_swagger.js
@@ -12,10 +12,14 @@ swagger.register = () => {
     verb: 'get',
     path: 'swagger.json'
   }, (request, resourceConfig, res) => {
-    if (!swagger._cache) {
-      swagger._cache = swaggerGenerator.generateDocumentation()
+    const { originalReq: { host, protocol } } = request
+    const serviceInstance = { host, protocol }
+    const key = `${protocol}://${host}`
+    swagger._cache = swagger._cache || {}
+    if (!swagger._cache[key]) {
+      swagger._cache[key] = swaggerGenerator.generateDocumentation(serviceInstance)
     }
 
-    return res.json(swagger._cache)
+    return res.json(swagger._cache[key])
   })
 }

--- a/lib/swagger/index.js
+++ b/lib/swagger/index.js
@@ -25,8 +25,8 @@ swagger._getSwaggerBase = serviceInstance => {
     basePath = jsonApi._apiConfig.base.substring(0, jsonApi._apiConfig.base.length - 1)
     protocol = jsonApi._apiConfig.protocol
   }
-  host = host || serviceInstance.host
-  protocol = protocol || serviceInstance.protocol
+  host = host || (serviceInstance && serviceInstance.host)
+  protocol = protocol || (serviceInstance && serviceInstance.protocol)
 
   return {
     swagger: '2.0',

--- a/lib/swagger/index.js
+++ b/lib/swagger/index.js
@@ -5,26 +5,29 @@ const url = require('url')
 const swaggerPaths = require('./paths.js')
 const swaggerResources = require('./resources.js')
 
-swagger.generateDocumentation = () => {
-  const swaggerDoc = swagger._getSwaggerBase()
+swagger.generateDocumentation = serviceInstance => {
+  const swaggerDoc = swagger._getSwaggerBase(serviceInstance)
   swaggerDoc.paths = swaggerPaths.getPathDefinitions(jsonApi)
   swaggerDoc.definitions = swaggerResources.getResourceDefinitions(jsonApi)
   return swaggerDoc
 }
 
-swagger._getSwaggerBase = () => {
+swagger._getSwaggerBase = serviceInstance => {
   const swaggerConfig = jsonApi._apiConfig.swagger || { }
   let basePath, host, protocol
   if (jsonApi._apiConfig.urlPrefixAlias) {
     const urlObj = url.parse(jsonApi._apiConfig.urlPrefixAlias)
     basePath = urlObj.pathname.replace(/(?!^\/)\/$/, '')
     host = urlObj.host
-    protocol = urlObj.protocol.replace(/:$/, '')
+    protocol = urlObj.protocol && urlObj.protocol.replace(/:$/, '')
   } else {
     host = jsonApi._apiConfig.host
     basePath = jsonApi._apiConfig.base.substring(0, jsonApi._apiConfig.base.length - 1)
     protocol = jsonApi._apiConfig.protocol
   }
+  host = host || serviceInstance.host
+  protocol = protocol || serviceInstance.protocol
+
   return {
     swagger: '2.0',
     info: {


### PR DESCRIPTION
The following changes were required by Gliffy Project
* give access to the original (express) request and response objects in the handlers
* support relative urlPrefixAlias in the swagger documentation generation; use the host and protocol from the request object
* remove the url prefix alias from the path when re-routing
